### PR TITLE
Issue #31 Write email html to watchlist dir * Write the generated email to disk so that it can be served from the web server. This will allow users with out support for HTML emails to view the HTML in a web browser.

### DIFF
--- a/assets/templates/email.html.tmpl
+++ b/assets/templates/email.html.tmpl
@@ -2,7 +2,7 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=us-ascii"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
-        <title>{{.ServerURL}} - Ebidlocal OnLine Auction Watch Lists</title>
+        <title>{{.ServerURL}} - Ebidlocal OnLine Auction Watch Lists Email</title>
         <style>
             td.photo img {
                 width: 350px;
@@ -45,5 +45,8 @@
             {{end}}
             </tbody>
         </table>
+        <p>
+        Not able to view this email? Visit <a href="{{.EmailLink}}" title="HTML page verision of this email">here</a> to view the html version of this email.
+        </p>
     </body>
 </html>

--- a/internal/app/extract/ExtractAuctionItem.go
+++ b/internal/app/extract/ExtractAuctionItem.go
@@ -174,6 +174,7 @@ func (s *AuctionItem) extract(in <-chan model.SearchResult, out chan<- model.Auc
 		doc.Find("body > div.row").Each(func(i int, selection *goquery.Selection) {
 			m := model.AuctionItem{
 				ParentAuctionID: result.AuctionID,
+				Keywords:        []string{result.Keyword},
 			}
 			s.scraper.Scrape(selection, &m)
 


### PR DESCRIPTION
<!--
Please fill in some brief details below about the PR.
Please remove unused sections.
 -->
### Issue Number
Issue #31 
Issue #35 

### Description
Address issue 31 and 35


### Pre Pull Request Checklist:
- [ ] Ran `fmt`.
- [ ] Ran with out errors.
- [ ] Unit tests.
- [ ] Unit tests have `issue number`
- [ ] Integration tests.
