### PR TITLE
Issue #50: Removed duplicate keys from watch lists

### DIFF
--- a/internal/pkg/ebidlocal/model/watchlist.go
+++ b/internal/pkg/ebidlocal/model/watchlist.go
@@ -1,6 +1,9 @@
 package model
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/scirelli/auction-ebidlocal-search/internal/pkg/id"
 	"github.com/scirelli/auction-ebidlocal-search/internal/pkg/iter/stringiter"
 )
@@ -13,4 +16,22 @@ func (w Watchlist) ID() string {
 
 func (w Watchlist) Iterator() stringiter.Iterator {
 	return stringiter.SliceStringIterator(w).Iterator()
+}
+
+func (w *Watchlist) Normalize() *Watchlist {
+	set := make(map[string]struct{})
+	for _, s := range *w {
+		set[s] = struct{}{}
+	}
+
+	i := 0
+	tmp := Watchlist(make([]string, len(set)))
+	for key := range set {
+		tmp[i] = strings.ToLower(key)
+		i++
+	}
+
+	*w = tmp
+	sort.Strings(*w)
+	return w
 }

--- a/internal/pkg/ebidlocal/store/fs/WatchlistStore.go
+++ b/internal/pkg/ebidlocal/store/fs/WatchlistStore.go
@@ -39,6 +39,7 @@ type WatchlistStoreConfig struct {
 }
 
 func (wl *WatchlistStore) SaveWatchlist(ctx context.Context, list model.Watchlist) (ID string, err error) {
+	list.Normalize()
 	if err = wl.addWatchlist(list); err != nil {
 		return "", err
 	}
@@ -46,7 +47,9 @@ func (wl *WatchlistStore) SaveWatchlist(ctx context.Context, list model.Watchlis
 }
 
 func (wl *WatchlistStore) LoadWatchlist(ctx context.Context, watchlistID string) (model.Watchlist, error) {
-	return wl.loadWatchlist(filepath.Join(wl.Config.WatchlistDir, watchlistID, wl.Config.DataFileName))
+	list, err := wl.loadWatchlist(filepath.Join(wl.Config.WatchlistDir, watchlistID, wl.Config.DataFileName))
+	list.Normalize()
+	return list, err
 }
 
 func (wl *WatchlistStore) DeleteWatchlist(ctx context.Context, watchlistID string) error {


### PR DESCRIPTION
<!--
Please fill in some brief details below about the PR.
Please remove unused sections.
 -->
### Issue Number
Issue #50

### Description
* Removed duplicate keywords when storing and loading watch lists.

### Pre Pull Request Checklist:
- [ ] Ran `fmt`.
- [ ] Ran with out errors.
- [ ] Unit tests.
- [ ] Unit tests have `issue number`
- [ ] Integration tests.
